### PR TITLE
Add handles for event listeners

### DIFF
--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -9,10 +9,7 @@ fn main() {
 
     let drpc_thread = drpc.start();
 
-    println!("blocking");
     drpc.block_until_event(Event::Ready).unwrap();
-
-    println!("done");
 
     // Set the activity
     drpc.set_activity(|act| act.state("rusting frfr"))

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -7,25 +7,12 @@ fn main() {
 
     let mut drpc = DiscordRPC::new(1003450375732482138);
 
-    drpc.on_ready(|_ctx| {
-        println!("ready?");
-    });
-
-    drpc.on_activity_join_request(|ctx| {
-        println!("Join request: {:?}", ctx.event);
-    });
-
-    drpc.on_activity_join(|ctx| {
-        println!("Joined: {:?}", ctx.event);
-    });
-
-    drpc.on_activity_spectate(|ctx| {
-        println!("Spectate: {:?}", ctx.event);
-    });
-
     let drpc_thread = drpc.start();
 
+    println!("blocking");
     drpc.block_until_event(Event::Ready).unwrap();
+
+    println!("done");
 
     // Set the activity
     drpc.set_activity(|act| act.state("rusting frfr"))

--- a/examples/discord_presence_subscriber.rs
+++ b/examples/discord_presence_subscriber.rs
@@ -7,26 +7,23 @@ fn main() {
 
     let mut drpc = DiscordRPC::new(1003450375732482138);
 
-    drpc.on_ready(|_ctx| {
-        println!("READY!");
+    let _ready = drpc.on_ready(|_ctx| {
+        println!("ready?");
     });
 
-    drpc.on_error(|ctx| {
-        eprintln!("An error occured, {}", ctx.event);
+    let _activity_join_request = drpc.on_activity_join_request(|ctx| {
+        println!("Join request: {:?}", ctx.event);
+    });
+
+    let _activity_join = drpc.on_activity_join(|ctx| {
+        println!("Joined: {:?}", ctx.event);
+    });
+
+    let _activity_spectate = drpc.on_activity_spectate(|ctx| {
+        println!("Spectate: {:?}", ctx.event);
     });
 
     let drpc_thread = drpc.start();
-
-    if let Err(why) = drpc.set_activity(|a| {
-        a.state("Running examples").assets(|ass| {
-            ass.large_image("ferris_wat")
-                .large_text("wat.")
-                .small_image("rusting")
-                .small_text("rusting...")
-        })
-    }) {
-        println!("Failed to set presence: {}", why);
-    }
 
     drpc_thread.join().unwrap()
 }

--- a/examples/unblocking.rs
+++ b/examples/unblocking.rs
@@ -1,3 +1,5 @@
+use std::{mem::forget, thread::sleep, time::Duration};
+
 use discord_presence::Client;
 
 fn main() {
@@ -9,13 +11,38 @@ fn main() {
 
     _ = client.start();
 
-    client
-        .set_activity(|a| {
-            a.state("Rust")
-                .details("Programming")
-                .assets(|a| a.large_image("rust"))
-        })
-        .unwrap();
+    {
+        let ready = client.on_ready({
+            let mut client = client.clone();
+
+            move |_ctx| {
+                println!("READY!");
+
+                client
+                    .set_activity(|a| {
+                        a.state("Rust")
+                            .details("Programming")
+                            .assets(|a| a.large_image("rust"))
+                    })
+                    .unwrap();
+            }
+        });
+
+        // we can `std::mem::forget` the event listener's handle to keep it
+        // registered until `drpc` is dropped
+        forget(ready);
+    }
+
+    // an alternative is to store the handle until you're ready to unregister the
+    // listener
+    let _error = client.on_error(|ctx| {
+        eprintln!("An error occured, {}", ctx.event);
+    });
 
     tracing::trace!("Made it to the final line");
+
+    // keep the main thread alive
+    loop {
+        sleep(Duration::from_secs(100));
+    }
 }

--- a/examples/unblocking.rs
+++ b/examples/unblocking.rs
@@ -13,9 +13,9 @@ fn main() {
 
     {
         let ready = client.on_ready({
-            let mut client = client.clone();
-
+            let client = client.clone();
             move |_ctx| {
+                let mut client = client.clone();
                 println!("READY!");
 
                 client

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,7 +30,7 @@ macro_rules! event_handler_function {
             #[doc = concat!("Listens for the `", stringify!($event), "` event")]
             #[must_use = "event listeners will be immediately dropped if the handle is not kept"]
             pub fn $name<F>(&self, handler: F) -> EventCallbackHandle
-                where F: FnMut(EventContext) + 'static + Send + Sync
+                where F: Fn(EventContext) + 'static + Send + Sync
             {
                 self.on_event($event, handler)
             }
@@ -199,7 +199,7 @@ impl Client {
     #[must_use = "event listeners will be immediately dropped if the handle is not kept"]
     pub fn on_event<F>(&self, event: Event, handler: F) -> EventCallbackHandle
     where
-        F: FnMut(EventContext) + 'static + Send + Sync,
+        F: Fn(EventContext) + 'static + Send + Sync,
     {
         self.event_handler_registry.register(event, handler)
     }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1,11 +1,15 @@
-use crate::{models::Event, Result};
+use crate::models::Event;
 use parking_lot::RwLock;
 use serde_json::Value as JsonValue;
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Weak},
+    thread,
+};
 
-type Handler<'a> = Box<dyn Fn(Context) + 'a + Send + Sync>;
+type Handler = dyn FnMut(Context) + Send + Sync;
 
-type HandlerList<'a> = Vec<Handler<'a>>;
+type HandlerList = Vec<Arc<RwLock<Handler>>>;
 
 #[derive(Debug, Clone)]
 pub struct Context {
@@ -19,55 +23,138 @@ impl Context {
     }
 }
 
-#[derive(Clone)]
-pub struct HandlerRegistry<'a> {
-    handlers: Arc<RwLock<HashMap<Event, HandlerList<'a>>>>,
+type Handlers = RwLock<HashMap<Event, HandlerList>>;
+
+pub struct EventCallbackHandle {
+    event: Event,
+    registry: Weak<HandlerRegistry>,
+    handler: Weak<RwLock<Handler>>,
 }
 
-impl<'a> HandlerRegistry<'a> {
+impl Drop for EventCallbackHandle {
+    fn drop(&mut self) {
+        // if the registry or this event handler has already been dropped, there's no reason to try and do it again
+        if let (Some(registry), Some(handler)) = (self.registry.upgrade(), self.handler.upgrade()) {
+            registry.remove(self.event, &handler);
+        }
+    }
+}
+
+pub struct HandlerRegistry {
+    handlers: Handlers,
+}
+
+impl HandlerRegistry {
     pub fn new() -> Self {
         Self {
-            handlers: Arc::new(RwLock::new(HashMap::new())),
+            handlers: RwLock::new(HashMap::new()),
         }
     }
 
-    pub fn register<F>(&mut self, event: Event, handler: F)
+    pub fn register<F>(self: &Arc<Self>, event: Event, handler: F) -> EventCallbackHandle
     where
-        F: Fn(Context) + 'a + Send + Sync,
+        F: FnMut(Context) + Send + Sync + 'static,
     {
+        let handler: Arc<RwLock<Handler>> = Arc::new(RwLock::new(handler));
+        let callback_handle = EventCallbackHandle {
+            event,
+            registry: Arc::downgrade(self),
+            handler: Arc::downgrade(&handler),
+        };
+
         let mut event_handlers = self.handlers.write();
         let event_handler = event_handlers.entry(event).or_default();
-        event_handler.push(Box::new(handler));
+        event_handler.push(handler);
+
+        callback_handle
     }
 
-    pub fn handle(&mut self, event: Event, data: JsonValue) -> Result<()> {
-        let handlers = self.handlers.read();
-        if let Some(handlers) = handlers.get(&event) {
-            let context = Context::new(data);
+    pub fn handle(self: Arc<Self>, event: Event, data: JsonValue) {
+        thread::spawn(move || {
+            let handlers = self.handlers.read();
+            if let Some(handlers) = handlers.get(&event) {
+                let context = Context::new(data);
 
-            for handler in handlers {
-                handler(context.clone())
+                for handler in handlers {
+                    let context = context.clone();
+                    let mut handler = handler.write();
+                    handler(context);
+                }
+            }
+        });
+    }
+
+    /// Removes a handler from the registry, if it exists
+    ///
+    /// Returns `true` if a change was made
+    pub fn remove(self: &Arc<Self>, event: Event, target: &Arc<RwLock<Handler>>) -> bool {
+        let mut handlers = self.handlers.write();
+        if let Some(handlers) = handlers.get_mut(&event) {
+            if let Some(index) = handlers
+                .iter()
+                .position(|handler| Arc::ptr_eq(handler, target))
+            {
+                _ = handlers.remove(index);
+                return true;
             }
         }
 
-        Ok(())
+        false
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::mem::forget;
+
     use super::*;
 
     #[test]
     fn can_register_event_handlers() {
-        let mut registry = HandlerRegistry::new();
-        registry.register(Event::Ready, |_| unimplemented!());
-        registry.register(Event::Ready, |_| unimplemented!());
-        registry.register(Event::Error, |_| unimplemented!());
+        let registry = Arc::new(HandlerRegistry::new());
+        let _ready1 = registry.register(Event::Ready, |_| unimplemented!());
+        let _ready2 = registry.register(Event::Ready, |_| unimplemented!());
+        let _error = registry.register(Event::Error, |_| unimplemented!());
 
         let handlers = registry.handlers.read();
         assert_eq!(handlers.len(), 2);
         assert_eq!(handlers[&Event::Ready].len(), 2);
         assert_eq!(handlers[&Event::Error].len(), 1);
+    }
+
+    /// Removes event handlers once they go out of scope to prevent memory leaks
+    #[test]
+    fn auto_remove_event_handlers() {
+        let registry = Arc::new(HandlerRegistry::new());
+        let _ready1 = registry.register(Event::Ready, |_| unimplemented!());
+        let _error = registry.register(Event::Error, |_| unimplemented!());
+
+        {
+            let _ready2 = registry.register(Event::Ready, |_| unimplemented!());
+        }
+        // _ready2 is automatically removed
+
+        let handlers = registry.handlers.read();
+        assert_eq!(handlers.len(), 2);
+        assert_eq!(handlers[&Event::Ready].len(), 1);
+        assert_eq!(handlers[&Event::Error].len(), 1);
+    }
+
+    /// Enables keeping an event callback for the entire lifetime of the client.
+    /// This disables the functionality tested in `auto_remove_event_handlers`.
+    #[test]
+    fn forget_cb_handles() {
+        let registry = Arc::new(HandlerRegistry::new());
+
+        {
+            let _ready = registry.register(Event::Ready, |_| unimplemented!());
+            // skip the Drop impl by running std::mem::forget
+            forget(_ready);
+        }
+        // _ready2 is not automatically removed
+
+        let handlers = registry.handlers.read();
+        assert_eq!(handlers.len(), 1);
+        assert_eq!(handlers[&Event::Ready].len(), 1);
     }
 }


### PR DESCRIPTION
Hi! I heard you were interested in a pull request with this feature. This change makes it so that registering events returns a "handle", which, when dropped, removes the event handler. This change would break most, if not all, existing code using this crate.