### PR TITLE
fix(connection manager): not sleeping if failed to connect

### DIFF
--- a/src/connection/manager.rs
+++ b/src/connection/manager.rs
@@ -120,8 +120,6 @@ fn send_and_receive_loop(manager: &mut Manager, rx: Receiver<()>) {
                     Err(why) => trace!("discord error: {}", why),
                     _ => {}
                 }
-
-                thread::sleep(time::Duration::from_millis(500));
             }
             None => match manager.connect() {
                 Err(err) => {
@@ -143,6 +141,8 @@ fn send_and_receive_loop(manager: &mut Manager, rx: Receiver<()>) {
                 _ => manager.handshake_completed = true,
             },
         }
+
+        thread::sleep(time::Duration::from_millis(500));
     }
 }
 


### PR DESCRIPTION
Thanks to the fix in #62, connection errors can now be correctly caught. The library also automatically re-tries the connection, which is awesome :)

The current implementation however only sleeps on a successful connection, which means if discord isn't running the socket and error log both get spammed. 

This moves the sleep outside of the `match` block so it runs regardless of connection outcome, meaning the library will now wait 500ms between connection retries.