### PR TITLE
Turn off weird debug printing

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -189,7 +189,7 @@ impl Client {
         );
         self.connection_manager.send(message?)?;
         let Message { payload, .. } = self.connection_manager.recv()?;
-        let response: Payload<E> = serde_json::from_str(&dbg!(payload))?;
+        let response: Payload<E> = serde_json::from_str(&payload)?;
 
         match response.evt {
             Some(Event::Error) => Err(DiscordError::SubscriptionFailed),


### PR DESCRIPTION
The payload get's printed before/after every request.
Hopefully it's not because of some env vars on my end.

edit: ok the commit message is a little dumb, sorry