### PR TITLE
Sleep on connection failure

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,7 @@
 use std::{
     sync::{atomic::Ordering, Arc},
     thread::{JoinHandle, Thread},
+    time::Duration,
 };
 
 use crate::{
@@ -100,8 +101,15 @@ impl Client {
     /// Creates a new `Client`
     #[must_use]
     pub fn new(client_id: u64) -> Self {
+        Self::with_error_sleep(client_id, Duration::from_millis(500))
+    }
+
+    /// Creates a new `Client` with a custom error sleep duration
+    #[must_use]
+    pub fn with_error_sleep(client_id: u64, error_sleep: Duration) -> Self {
         let event_handler_registry = Arc::new(HandlerRegistry::new());
-        let connection_manager = ConnectionManager::new(client_id, event_handler_registry.clone());
+        let connection_manager =
+            ConnectionManager::new(client_id, event_handler_registry.clone(), error_sleep);
 
         Self {
             connection_manager,

--- a/src/client.rs
+++ b/src/client.rs
@@ -101,15 +101,23 @@ impl Client {
     /// Creates a new `Client`
     #[must_use]
     pub fn new(client_id: u64) -> Self {
-        Self::with_error_sleep(client_id, Duration::from_millis(500))
+        Self::with_error_config(client_id, Duration::from_millis(500), None)
     }
 
-    /// Creates a new `Client` with a custom error sleep duration
+    /// Creates a new `Client` with a custom error sleep duration, and number of attempts
     #[must_use]
-    pub fn with_error_sleep(client_id: u64, error_sleep: Duration) -> Self {
+    pub fn with_error_config(
+        client_id: u64,
+        sleep_duration: Duration,
+        attempts: Option<usize>,
+    ) -> Self {
         let event_handler_registry = Arc::new(HandlerRegistry::new());
-        let connection_manager =
-            ConnectionManager::new(client_id, event_handler_registry.clone(), error_sleep);
+        let connection_manager = ConnectionManager::new(
+            client_id,
+            event_handler_registry.clone(),
+            sleep_duration,
+            attempts,
+        );
 
         Self {
             connection_manager,

--- a/src/client.rs
+++ b/src/client.rs
@@ -98,10 +98,10 @@ pub struct Client {
 impl bevy::ecs::system::Resource for Client {}
 
 impl Client {
-    /// Creates a new `Client`
+    /// Creates a new `Client` with default error sleep duration of 5 seconds, and no limit on connection attempts
     #[must_use]
     pub fn new(client_id: u64) -> Self {
-        Self::with_error_config(client_id, Duration::from_millis(500), None)
+        Self::with_error_config(client_id, Duration::from_secs(5), None)
     }
 
     /// Creates a new `Client` with a custom error sleep duration, and number of attempts

--- a/src/connection/manager.rs
+++ b/src/connection/manager.rs
@@ -149,7 +149,7 @@ fn send_and_receive_loop(manager: &mut Manager, rx: &Receiver<()>) {
                     }
                     error!("Failed to connect: {:?}", err);
 
-                    thread::sleep(time::Duration::from_millis(500));
+                    thread::sleep(time::Duration::from_secs(5));
                 }
                 _ => manager.handshake_completed = true,
             },

--- a/src/connection/manager.rs
+++ b/src/connection/manager.rs
@@ -148,6 +148,8 @@ fn send_and_receive_loop(manager: &mut Manager, rx: &Receiver<()>) {
                         break;
                     }
                     error!("Failed to connect: {:?}", err);
+
+                    thread::sleep(time::Duration::from_millis(500));
                 }
                 _ => manager.handshake_completed = true,
             },


### PR DESCRIPTION
I've added a 5 second sleep each time a connection is attempted but fails.

This will usually happen if Discord isn't running, and since it isn't imperative that a connection is made immediately after Discord starts I've gone for lower power usage instead of an immediate connection.

If Discord is already running, then nothing changes and a connection is made instantly as usual. The sleep only runs if a connection fails.

Closes #95 