### PR TITLE
Support for different activity types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,35 @@ I will add links where possible, including retroactively if possible.
 
 ## [Unreleased](https://github.com/jewlexx/discord-presence/tree/trunk)
 
-## [0.6.0]
+## [1.2.0](https://github.com/jewlexx/discord-presence/releases/tag/v1.2.0)
+
+### Changed
+
+- Sleep on connection failure
+
+## [1.1.2](https://github.com/jewlexx/discord-presence/releases/tag/v1.1.2)
+
+### Fixed
+
+- Missing buttons field
+
+## [1.1.1](https://github.com/jewlexx/discord-presence/releases/tag/v1.1.1)
+
+### Fixed
+
+- Shutdown function incorrectly throwing NotStarted error
+
+## [1.1.0](https://github.com/jewlexx/discord-presence/releases/tag/v1.1.0)
+
+### Fixed
+
+- Debug printing in release
+
+### Added
+
+- PartialUser struct
+
+## [1.0.0](https://github.com/jewlexx/discord-presence/releases/tag/v1.0.0)
 
 ### Breaking Changes
 
@@ -22,10 +50,9 @@ I will add links where possible, including retroactively if possible.
 ### Added
 
 - Ability to remove event handlers [#40](https://github.com/jewlexx/discord-presence/issues/40)
-
-### Added
-
 - Support buttons [#38](https://github.com/jewlexx/discord-presence/issues/38)
+- Client can now be cloned
+- Better types for the Error event
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ I will add links where possible, including retroactively if possible.
 
 ## [Unreleased](https://github.com/jewlexx/discord-presence/tree/trunk)
 
+### Added
+
+- Support for different activity types by [@natawie](https://github.com/natawie) [#118](https://github.com/jewlexx/discord-presence/pull/118)
+
 ## [1.2.0](https://github.com/jewlexx/discord-presence/releases/tag/v1.2.0)
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ quork = { version = "0.7", default-features = false, features = [
     "traits",
 ] }
 serde_json = "1.0"
+serde_repr = "0.1"
 thiserror = "1.0"
 tracing = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/jewlexx/discord-presence.git"
 rust-version = "1.66.1"
 version = "1.2.0"
 
+[features]
+activity_type = ["dep:serde_repr"]
+
 [dependencies]
 byteorder = "1.5"
 bytes = "1.6"
@@ -25,7 +28,7 @@ quork = { version = "0.7", default-features = false, features = [
     "traits",
 ] }
 serde_json = "1.0"
-serde_repr = "0.1"
+serde_repr = { version = "0.1", optional = true }
 thiserror = "1.0"
 tracing = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ version = "1.2.0"
 [features]
 activity_type = ["dep:serde_repr"]
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 byteorder = "1.5"
 bytes = "1.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
     clippy::pedantic
 )]
 #![forbid(unsafe_code)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! A Rust library that allows the developer to interact with the Discord Presence API with ease
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,7 +9,8 @@ macro_rules! builder_func_doc {
 }
 
 macro_rules! builder_func {
-    [ $name:ident, $type:tt func ] => {
+    [ $name:ident, $type:tt func $(=> if feature = $feature:tt)? ] => {
+        $(#[cfg(feature = $feature)])?
         #[doc = builder_func_doc!($type)]
         #[must_use]
         pub fn $name<F>(mut self, func: F) -> Self
@@ -19,7 +20,8 @@ macro_rules! builder_func {
         }
     };
 
-    [ $name:ident, String ] => {
+    [ $name:ident, String $(=> if feature = $feature:tt)? ] => {
+        $(#[cfg(feature = $feature)])?
         #[doc = builder_func_doc!(Stringish)]
         #[must_use]
         pub fn $name<S>(mut self, value: S) -> Self
@@ -29,7 +31,8 @@ macro_rules! builder_func {
         }
     };
 
-    [ $name:ident, $type:ty ] => {
+    [ $name:ident, $type:ty $(=> if feature = $feature:tt)? ] => {
+        $(#[cfg(feature = $feature)])?
         #[doc = builder_func_doc!($type)]
         #[must_use]
         pub fn $name(mut self, value: $type) -> Self {
@@ -76,10 +79,11 @@ macro_rules! into_error {
 }
 
 macro_rules! builder {
-    [ @st ( $name:ident $field:tt: $type:tt alias = $alias:tt, $($rest:tt)* ) -> ( $($out:tt)* ) ] => {
+    [ @st ( $name:ident $field:tt: $type:tt alias = $alias:tt $(=> if feature = $feature:tt)?, $($rest:tt)* ) -> ( $($out:tt)* ) ] => {
         builder![ @st
             ( $name $($rest)* ) -> (
                 $($out)*
+                $(#[cfg(feature = $feature)])?
                 #[doc = concat!("Optional " , stringify!($field), " field")]
                 #[serde(skip_serializing_if = "Option::is_none", rename = $alias)]
                 pub $field: Option<$type>,
@@ -87,7 +91,7 @@ macro_rules! builder {
         ];
     };
 
-    [ @st ( $name:ident $field:tt: $type:tt func, $($rest:tt)* ) -> ( $($out:tt)* ) ] => {
+    [ @st ( $name:ident $field:tt: $type:tt func $(=> if feature = $feature:tt)?, $($rest:tt)* ) -> ( $($out:tt)* ) ] => {
         builder![ @st ( $name $field: $type, $($rest)* ) -> ( $($out)* ) ];
     };
 
@@ -105,7 +109,7 @@ macro_rules! builder {
     };
 
 
-    [ @st ( $name:ident $field:ident: $type:ty, $($rest:tt)* ) -> ( $($out:tt)* ) ] => {
+    [ @st ( $name:ident $field:ident: $type:ty $(=> if feature = $feature:tt)?, $($rest:tt)* ) -> ( $($out:tt)* ) ] => {
         builder![ @st
             ( $name $($rest)* ) -> (
                 $($out)*
@@ -122,20 +126,20 @@ macro_rules! builder {
         pub struct $name { $($out)* }
     };
 
-    [ @im ( $name:ident $field:ident: $type:tt func, $($rest:tt)* ) -> ( $($out:tt)* ) ] => {
-        builder![ @im ( $name $($rest)* ) -> ( builder_func![$field, $type func]; $($out)* ) ];
+    [ @im ( $name:ident $field:ident: $type:tt func $(=> if feature = $feature:tt)?, $($rest:tt)* ) -> ( $($out:tt)* ) ] => {
+        builder![ @im ( $name $($rest)* ) -> ( builder_func![$field, $type func $(=> if feature = $feature)?]; $($out)* ) ];
     };
 
-    [ @im ( $name:ident $field:ident: $type:tt as array, $($rest:tt)* ) -> ( $($out:tt)* ) ] => {
+    [ @im ( $name:ident $field:ident: $type:tt as array $(=> if feature = $feature:tt)?, $($rest:tt)* ) -> ( $($out:tt)* ) ] => {
         builder![ @im ( $name $($rest)* ) -> ( builder_array![$field, $type array]; $($out)* ) ];
     };
 
-    [ @im ( $name:ident $field:ident: $type:tt alias = $modifier:tt, $($rest:tt)* ) -> ( $($out:tt)* ) ] => {
-        builder![ @im ( $name $field: $type, $($rest)* ) -> ( $($out)* ) ];
+    [ @im ( $name:ident $field:ident: $type:tt alias = $modifier:tt $(=> if feature = $feature:tt)?, $($rest:tt)* ) -> ( $($out:tt)* ) ] => {
+        builder![ @im ( $name $field: $type $(=> if feature = $feature)?, $($rest)* ) -> ( $($out)* ) ];
     };
 
-    [ @im ( $name:ident $field:ident: $type:tt, $($rest:tt)* ) -> ( $($out:tt)* ) ] => {
-        builder![ @im ( $name $($rest)* ) -> ( builder_func![$field, $type]; $($out)* ) ];
+    [ @im ( $name:ident $field:ident: $type:tt $(=> if feature = $feature:tt)?, $($rest:tt)* ) -> ( $($out:tt)* ) ] => {
+        builder![ @im ( $name $($rest)* ) -> ( builder_func![$field, $type $(=> if feature = $feature)?]; $($out)* ) ];
     };
 
     [ @im ( $name:ident ) -> ( $($out:tt)* ) ] => {

--- a/src/models/rich_presence.rs
+++ b/src/models/rich_presence.rs
@@ -1,6 +1,7 @@
 use std::default::Default;
 
 use serde::Deserializer;
+use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use super::events::PartialUser;
 use crate::utils;
@@ -56,6 +57,21 @@ impl SendActivityJoinInviteArgs {
     }
 }
 
+/// ActivityType enum
+#[repr(u8)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize_repr, Serialize_repr, Hash)]
+#[serde(untagged)]
+pub enum ActivityType {
+    /// Playing a game
+    Playing = 0,
+    /// Listening to...
+    Listening = 2,
+    /// Watching...
+    Watching = 3,
+    /// Competing in...
+    Competing = 5,
+}
+
 builder! {ActivityJoinEvent
     secret: String,
 }
@@ -72,6 +88,7 @@ builder! {Activity
     state: String,
     details: String,
     instance: bool,
+    _type: ActivityType alias = "type",
     timestamps: ActivityTimestamps func,
     assets: ActivityAssets func,
     party: ActivityParty func,

--- a/src/models/rich_presence.rs
+++ b/src/models/rich_presence.rs
@@ -181,6 +181,7 @@ mod tests {
             .state("rusting")
             .details("detailed")
             .instance(true)
+            ._type(ActivityType::Watching)
             .timestamps(|t| t.start(1000).end(2000))
             .assets(|a| {
                 a.large_image("ferris")

--- a/src/models/rich_presence.rs
+++ b/src/models/rich_presence.rs
@@ -183,7 +183,6 @@ mod tests {
             .state("rusting")
             .details("detailed")
             .instance(true)
-            ._type(ActivityType::Watching)
             .timestamps(|t| t.start(1000).end(2000))
             .assets(|a| {
                 a.large_image("ferris")
@@ -209,3 +208,19 @@ mod tests {
         assert_eq![json, "{}"];
     }
 }
+
+#[cfg(test)]
+#[cfg(feature = "activity_type")]
+mod activity_type_tests {
+    use super::*;
+
+    #[test]
+    fn can_serialize_activity_type() {
+        let activity = Activity::new()
+            ._type(ActivityType::Watching);
+        let json = serde_json::to_string(&activity).expect("Failed to serialize into String");
+
+        assert_eq![json, r#"{"type":3}"#];
+    }
+}
+

--- a/src/models/rich_presence.rs
+++ b/src/models/rich_presence.rs
@@ -61,6 +61,7 @@ impl SendActivityJoinInviteArgs {
 
 /// ActivityType enum
 #[cfg(feature = "activity_type")]
+#[cfg_attr(docsrs, doc(cfg(feature = "activity_type")))]
 #[repr(u8)]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize_repr, Serialize_repr, Hash)]
 pub enum ActivityType {

--- a/src/models/rich_presence.rs
+++ b/src/models/rich_presence.rs
@@ -1,6 +1,8 @@
 use std::default::Default;
 
 use serde::Deserializer;
+
+#[cfg(feature = "activity_type")]
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use super::events::PartialUser;
@@ -58,9 +60,9 @@ impl SendActivityJoinInviteArgs {
 }
 
 /// ActivityType enum
+#[cfg(feature = "activity_type")]
 #[repr(u8)]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize_repr, Serialize_repr, Hash)]
-#[serde(untagged)]
 pub enum ActivityType {
     /// Playing a game
     Playing = 0,
@@ -88,7 +90,7 @@ builder! {Activity
     state: String,
     details: String,
     instance: bool,
-    _type: ActivityType alias = "type",
+    _type: ActivityType alias = "type" => if feature = "activity_type",
     timestamps: ActivityTimestamps func,
     assets: ActivityAssets func,
     party: ActivityParty func,

--- a/tests/fixtures/activity_full.json
+++ b/tests/fixtures/activity_full.json
@@ -2,6 +2,7 @@
     "state": "rusting",
     "details": "detailed",
     "instance": true,
+    "type": 3,
     "timestamps": {
         "start": 1000,
         "end": 2000

--- a/tests/fixtures/activity_full.json
+++ b/tests/fixtures/activity_full.json
@@ -2,7 +2,6 @@
     "state": "rusting",
     "details": "detailed",
     "instance": true,
-    "type": 3,
     "timestamps": {
         "start": 1000,
         "end": 2000


### PR DESCRIPTION
Allows setting different activity types (e.g. "Listening to…", "Watching…")(#97)

Not [all activity types](https://discord.com/developers/docs/game-sdk/activities#data-models-activitytype-enum) are accepted when trying to set them, Streaming and Custom cause an error, so I left them out.

Although (I think) undocumented, it does work.
!["Listening to mpddrp-rs"](https://github.com/user-attachments/assets/dc5bf018-7fe9-41fb-8f92-335ace192294)
!["Competing in mpddrp-rs"](https://github.com/user-attachments/assets/9fd6674d-7442-4a5b-a1e9-05cf437288fb)
