### PR TITLE
fix(connection manager): unset ready on connection error

### DIFF
--- a/src/connection/manager.rs
+++ b/src/connection/manager.rs
@@ -153,6 +153,8 @@ fn send_and_receive_loop(
             }
             None => match manager.connect() {
                 Err(err) => {
+                    crate::READY.store(false, Ordering::Relaxed);
+
                     manager.event_handler_registry.handle(
                         Event::Error,
                         crate::models::EventData::Error(ErrorEvent {


### PR DESCRIPTION
Currently, there is no way to reliably detect when the client re-connects, as the `Ready` event is only ever triggered on the first successful connection.

By unsetting the READY atomic here, the client will re-send an `Event::Ready`, allowing consumers to detect this.

Arguably this is a bit of a bodge-job, as it sort of negates the point for the ready check. It might be a better idea to instead add a separate event specific to (re)connecting, or just remove the check altogether.

Related: https://github.com/JakeStanger/mpd-discord-rpc/issues/138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for connection attempts, ensuring the system accurately reflects the connection status when a failure occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->