### PR TITLE
feat(connection manager): send connected/disconnected events

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -391,6 +391,10 @@ impl Client {
     event_handler_function!(on_activity_join_request, Event::ActivityJoinRequest);
 
     event_handler_function!(on_activity_spectate, Event::ActivitySpectate);
+
+    event_handler_function!(on_connected, Event::Connected);
+
+    event_handler_function!(on_disconnected, Event::Disconnected);
 }
 
 #[cfg(test)]

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -38,6 +38,10 @@ pub enum Command {
 pub enum Event {
     /// [`Event::Ready`] event, fired when the client is ready, but not if an error occurs
     Ready,
+    /// [`Event::Connected`] event, fired when the client successfully connects (including re-connections)
+    Connected,
+    /// [`Event::Disconnected]` event, fired when the client was connected but loses connection
+    Disconnected,
     /// [`Event::Error`] event, overrides the `Ready` event
     Error,
     /// [`Event::ActivityJoin`] event, fired when the client's game is joined by a player
@@ -72,6 +76,8 @@ impl Event {
             Event::ActivityJoinRequest => serde_json::from_value(data.clone())
                 .map(EventData::ActivityJoinRequest)
                 .unwrap_or(EventData::Unknown(data)),
+
+            Event::Connected | Event::Disconnected => EventData::None,
         }
     }
 }
@@ -91,6 +97,8 @@ pub enum EventData {
     ActivityJoinRequest(ActivityJoinRequestEvent),
     /// [`EventData::Unknown`] event data
     Unknown(JsonValue),
+    /// [`EventData::None`] event data, used for events which send no data
+    None,
 }
 
 pub use commands::*;


### PR DESCRIPTION
These events are sent when client successfully connects, or loses connection. No data is sent.

This provides a reliable way of connecting when the client re-connects, as well as when it loses connection without needing to parse the error.

Supersedes #125   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced event handling for connection and disconnection states in the client.
	- Added new event types: `Connected` and `Disconnected`.

- **Improvements**
	- Enhanced connection lifecycle management by explicitly handling connection events.

- **Bug Fixes**
	- Updated event parsing to accommodate new event types, ensuring proper control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->