### PR TITLE
Increase response buffer size

### DIFF
--- a/src/connection/base.rs
+++ b/src/connection/base.rs
@@ -94,7 +94,7 @@ pub trait Connection: Sized {
     /// Receive a message from the server.
     fn recv(&mut self) -> Result<Message> {
         let mut buf = BytesMut::new();
-        buf.resize(1024, 0);
+        buf.resize(2048, 0);
         let n = self.socket().read(&mut buf)?;
         trace!("Received {} bytes", n);
 


### PR DESCRIPTION
Will fix #129.

It feels like a bit of a crude fix, but nothing else (such as [`Read::read_to_end`](https://doc.rust-lang.org/std/io/trait.Read.html#method.read_to_end)) worked. I'm not too familiar as to the reason why.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased buffer size for receiving messages, allowing for larger messages to be handled in a single operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->