### PR TITLE
Properly handle Discord's frame headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/jewlexx/discord-presence/tree/main)
 
+### Added
+
+- Support for properly handling frame headers from Discord
+  - This should result in slight performance improvements
+    from not allocating more than necessary.
+  - This also allows for larger payloads to be sent
+
 ## [1.4.1](https://github.com/jewlexx/discord-presence/releases/tag/v1.4.1)
 
 ### Fixed

--- a/examples/large_response.rs
+++ b/examples/large_response.rs
@@ -1,9 +1,10 @@
 use discord_presence::Event;
 
+mod helpers;
+
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::TRACE)
-        .init();
+    helpers::logging::init_logging();
+
     let url_base = "https://example.com/".to_string();
     let mut client = discord_presence::Client::new(1286481105410588672);
     client.start();

--- a/examples/large_response.rs
+++ b/examples/large_response.rs
@@ -10,21 +10,23 @@ fn main() -> anyhow::Result<()> {
     client.block_until_event(Event::Ready)?;
     client.set_activity(|activity| {
         activity
-            .state("A".to_string().repeat(128))
-            .details("A".to_string().repeat(128))
+            .state("A".repeat(128))
+            .details("A".repeat(128))
             .assets(|assets| {
                 assets
-                    .large_text("A".to_string().repeat(128))
-                    .large_image("A".to_string().repeat(256))
-                    .small_image("A".to_string().repeat(256))
-                    .small_text("A".to_string().repeat(128))
+                    .large_text("A".repeat(128))
+                    .large_image("A".repeat(256))
+                    .small_image("A".repeat(256))
+                    .small_text("A".repeat(128))
             })
             .append_buttons(|buttons| {
                 buttons
-                    .url(url_base.clone() + &"A".to_string().repeat(256 - url_base.len()))
-                    .label("A".to_string().repeat(32))
+                    .url(url_base.clone() + &"A".repeat(256 - url_base.len()))
+                    .label("A".repeat(32))
             })
     })?;
+
+    client.block_on()?;
 
     Ok(())
 }

--- a/examples/large_response.rs
+++ b/examples/large_response.rs
@@ -1,0 +1,30 @@
+use discord_presence::Event;
+
+fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::TRACE)
+        .init();
+    let url_base = "https://example.com/".to_string();
+    let mut client = discord_presence::Client::new(1286481105410588672);
+    client.start();
+    client.block_until_event(Event::Ready)?;
+    client.set_activity(|activity| {
+        activity
+            .state("A".to_string().repeat(128))
+            .details("A".to_string().repeat(128))
+            .assets(|assets| {
+                assets
+                    .large_text("A".to_string().repeat(128))
+                    .large_image("A".to_string().repeat(256))
+                    .small_image("A".to_string().repeat(256))
+                    .small_text("A".to_string().repeat(128))
+            })
+            .append_buttons(|buttons| {
+                buttons
+                    .url(url_base.clone() + &"A".to_string().repeat(256 - url_base.len()))
+                    .label("A".to_string().repeat(32))
+            })
+    })?;
+
+    Ok(())
+}

--- a/examples/large_response.rs
+++ b/examples/large_response.rs
@@ -10,19 +10,22 @@ fn main() -> anyhow::Result<()> {
     client.start();
     client.block_until_event(Event::Ready)?;
     client.set_activity(|activity| {
+        const ACTIVITY_TEXT_LIMIT: usize = 128;
+        const ASSET_URL_LIMIT: usize = 256;
+
         activity
             .state("A".repeat(128))
             .details("A".repeat(128))
             .assets(|assets| {
                 assets
-                    .large_text("A".repeat(128))
-                    .large_image("A".repeat(256))
-                    .small_image("A".repeat(256))
-                    .small_text("A".repeat(128))
+                    .large_text("A".repeat(ACTIVITY_TEXT_LIMIT))
+                    .large_image("A".repeat(ASSET_URL_LIMIT))
+                    .small_text("A".repeat(ACTIVITY_TEXT_LIMIT))
+                    .small_image("A".repeat(ASSET_URL_LIMIT))
             })
             .append_buttons(|buttons| {
                 buttons
-                    .url(url_base.clone() + &"A".repeat(256 - url_base.len()))
+                    .url(url_base.clone() + &"A".repeat(ASSET_URL_LIMIT - url_base.len()))
                     .label("A".repeat(32))
             })
     })?;

--- a/src/connection/base.rs
+++ b/src/connection/base.rs
@@ -115,7 +115,7 @@ pub trait Connection: Sized {
         trace!("Received {} bytes for payload", n);
 
         if n == 0 {
-            return Err(DiscordError::ConnectionClosed);
+            return Err(DiscordError::NoMessage);
         }
 
         let mut payload = String::with_capacity(header.message_length() as usize);

--- a/src/connection/base.rs
+++ b/src/connection/base.rs
@@ -117,7 +117,7 @@ pub trait Connection: Sized {
         let header = unsafe { FrameHeader::from_bytes(buf.as_ref()).unwrap_unchecked() };
 
         let mut message_buf = BytesMut::new();
-        message_buf.resize(header.message_length() as usize, 0);
+        message_buf.resize(header.message_length(), 0);
 
         trace!("Reading payload");
         let n = self.socket().read(&mut message_buf)?;
@@ -127,7 +127,7 @@ pub trait Connection: Sized {
             return Err(DiscordError::NoMessage);
         }
 
-        let mut payload = String::with_capacity(header.message_length() as usize);
+        let mut payload = String::with_capacity(header.message_length());
         message_buf.as_ref().read_to_string(&mut payload)?;
         trace!("<- {:?} = {:?}", header.opcode(), payload);
 

--- a/src/connection/base.rs
+++ b/src/connection/base.rs
@@ -109,9 +109,12 @@ pub trait Connection: Sized {
             return Err(DiscordError::ConnectionClosed);
         }
 
-        let Some(header) = (unsafe { FrameHeader::from_bytes(buf.as_ref()) }) else {
+        if n != std::mem::size_of::<FrameHeader>() {
             return Err(DiscordError::HeaderLength);
-        };
+        }
+
+        // SAFETY: the length of buf is already checked that the header is the correct size
+        let header = unsafe { FrameHeader::from_bytes(buf.as_ref()).unwrap_unchecked() };
 
         let mut message_buf = BytesMut::new();
         message_buf.resize(header.message_length() as usize, 0);

--- a/src/connection/base.rs
+++ b/src/connection/base.rs
@@ -30,6 +30,8 @@ macro_rules! try_until_done {
 pub trait Connection: Sized {
     type Socket: Write + Read;
 
+    /// Time for socket read/write operations
+    /// 1 second higher than Discord's rate limit timeout of 15 seconds
     const READ_WRITE_TIMEOUT: Duration = Duration::from_secs(16);
 
     /// The internally stored socket connection.

--- a/src/connection/manager.rs
+++ b/src/connection/manager.rs
@@ -137,9 +137,8 @@ fn send_and_receive_loop(
 
         match *connection {
             Some(ref conn) => {
-                let mut connection = conn.lock();
                 match send_and_receive(
-                    &mut connection,
+                    &mut conn.lock(),
                     &manager.event_handler_registry,
                     &mut inbound,
                     &outbound,
@@ -155,6 +154,8 @@ fn send_and_receive_loop(
                     Err(why) => trace!("discord error: {}", why),
                     _ => {}
                 }
+
+                debug!("Finished send and receive loop iteration");
 
                 thread::sleep(time::Duration::from_millis(500));
             }

--- a/src/connection/manager.rs
+++ b/src/connection/manager.rs
@@ -155,7 +155,7 @@ fn send_and_receive_loop(
                     _ => {}
                 }
 
-                debug!("Finished send and receive loop iteration");
+                trace!("Finished send and receive loop iteration");
 
                 thread::sleep(time::Duration::from_millis(500));
             }

--- a/src/connection/unix.rs
+++ b/src/connection/unix.rs
@@ -13,8 +13,8 @@ impl Connection for Socket {
         let connection_name = Self::socket_path(0);
         let socket = UnixStream::connect(connection_name)?;
         socket.set_nonblocking(true)?;
-        socket.set_write_timeout(Some(time::Duration::from_secs(30)))?;
-        socket.set_read_timeout(Some(time::Duration::from_secs(30)))?;
+        socket.set_read_timeout(Some(Self::READ_WRITE_TIMEOUT));
+        socket.set_write_timeout(Some(Self::READ_WRITE_TIMEOUT));
         Ok(Self { socket })
     }
 

--- a/src/connection/windows.rs
+++ b/src/connection/windows.rs
@@ -1,21 +1,20 @@
 use super::base::Connection;
 use crate::Result;
-use named_pipe::PipeClient;
 use std::{path::PathBuf, time};
 
 pub struct Socket {
-    socket: PipeClient,
+    socket: std::fs::File,
 }
 
 impl Connection for Socket {
-    type Socket = PipeClient;
+    type Socket = std::fs::File;
 
     fn connect() -> Result<Self> {
-        let connection_name = Self::socket_path(0);
-        let mut socket = PipeClient::connect(connection_name)?;
-        // Discord rate limit timeout is 15 seconds, so 16 should account for that
-        socket.set_write_timeout(Some(time::Duration::from_secs(16)));
-        socket.set_read_timeout(Some(time::Duration::from_secs(16)));
+        // TODO: Add timed out reads and writes to 16s
+        let socket = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(Self::socket_path(0))?;
         Ok(Self { socket })
     }
 

--- a/src/connection/windows.rs
+++ b/src/connection/windows.rs
@@ -13,7 +13,6 @@ impl Connection for Socket {
     type Socket = PipeClient;
 
     fn connect() -> Result<Self> {
-        // TODO: Add timed out reads and writes to 16s
         let mut socket = PipeClient::connect(Self::socket_path(0))?;
         socket.set_read_timeout(Some(Self::READ_WRITE_TIMEOUT));
         socket.set_write_timeout(Some(Self::READ_WRITE_TIMEOUT));

--- a/src/connection/windows.rs
+++ b/src/connection/windows.rs
@@ -1,20 +1,22 @@
+use std::path::PathBuf;
+
+use named_pipe::PipeClient;
+
 use super::base::Connection;
 use crate::Result;
-use std::{path::PathBuf, time};
 
 pub struct Socket {
-    socket: std::fs::File,
+    socket: PipeClient,
 }
 
 impl Connection for Socket {
-    type Socket = std::fs::File;
+    type Socket = PipeClient;
 
     fn connect() -> Result<Self> {
         // TODO: Add timed out reads and writes to 16s
-        let socket = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(Self::socket_path(0))?;
+        let mut socket = PipeClient::connect(Self::socket_path(0))?;
+        socket.set_read_timeout(Some(Self::READ_WRITE_TIMEOUT));
+        socket.set_write_timeout(Some(Self::READ_WRITE_TIMEOUT));
         Ok(Self { socket })
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,6 +45,9 @@ pub enum DiscordError {
     #[error("Error converting values")]
     /// Conversion Error
     Conversion,
+    #[error("Error decoding response. Incorrect header length")]
+    /// Header Length Error
+    HeaderLength,
     #[error("Error subscribing to an event")]
     /// Subscription Joining Error
     SubscriptionFailed,

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,9 @@ pub enum DiscordError {
     #[error("Error decoding response. Incorrect header length")]
     /// Header Length Error
     HeaderLength,
+    #[error("Header was received, but no message was received")]
+    /// Header was received, but no message was received
+    NoMessage,
     #[error("Error subscribing to an event")]
     /// Subscription Joining Error
     SubscriptionFailed,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
     clippy::all,
     clippy::pedantic
 )]
-#![forbid(unsafe_code)]
+// #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! A Rust library that allows the developer to interact with the Discord Presence API with ease

--- a/src/models/message.rs
+++ b/src/models/message.rs
@@ -5,21 +5,88 @@ use num_traits::FromPrimitive;
 use serde::Serialize;
 use std::io::{Read, Write};
 
+// const MAX_RPC_FRAME_SIZE: usize = 64 * 1024;
+
 /// Codes for payload types
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 #[repr(u32)]
 pub enum OpCode {
     /// Handshake payload
-    Handshake,
+    Handshake = 0,
     /// Frame payload
-    Frame,
+    Frame = 1,
     /// Close payload
-    Close,
+    Close = 2,
     /// Ping payload
-    Ping,
+    Ping = 3,
     /// Pong payload
-    Pong,
+    Pong = 4,
 }
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(C)]
+/// Header for the payload
+///
+/// Determines the length of the payload, and the type of payload
+pub struct FrameHeader {
+    /// The opcode for the payload
+    opcode: OpCode,
+    /// The length of the payload
+    length: u32,
+}
+
+impl FrameHeader {
+    #[must_use]
+    /// Convert an array of bytes to a [`FrameHeader`]
+    ///
+    /// # Safety
+    /// This reinterprets the bytes as a [`FrameHeader`]. It is up to the caller to ensure that the
+    /// bytes are valid.
+    pub unsafe fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != std::mem::size_of::<FrameHeader>() {
+            return None;
+        }
+
+        Some(unsafe { std::ptr::read_unaligned(bytes.as_ptr().cast()) })
+    }
+
+    #[must_use]
+    /// Get the expected message length
+    pub fn message_length(&self) -> u32 {
+        self.length
+    }
+
+    #[must_use]
+    /// Get the opcode
+    pub fn opcode(&self) -> OpCode {
+        self.opcode
+    }
+}
+
+// NOTE: Currently unused
+// Probably remove in future
+// #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+// #[repr(C)]
+// /// Frame passed over the socket
+// ///
+// /// Contains the header and the payload
+// pub struct Frame {
+//     /// The header for the payload
+//     header: FrameHeader,
+//     /// The actual payload
+//     message: [std::os::raw::c_char; MAX_RPC_FRAME_SIZE - std::mem::size_of::<FrameHeader>()],
+// }
+
+// impl From<Frame> for Message {
+//     fn from(header: Frame) -> Self {
+//         Self {
+//             opcode: header.header.opcode,
+//             payload: unsafe { CStr::from_ptr(header.message.as_ptr()) }
+//                 .to_string_lossy()
+//                 .into_owned(),
+//         }
+//     }
+// }
 
 /// Message struct for the Discord RPC
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/models/message.rs
+++ b/src/models/message.rs
@@ -5,7 +5,7 @@ use num_traits::FromPrimitive;
 use serde::Serialize;
 use std::io::{Read, Write};
 
-// const MAX_RPC_FRAME_SIZE: usize = 64 * 1024;
+pub(crate) const MAX_RPC_FRAME_SIZE: usize = 64 * 1024;
 
 /// Codes for payload types
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]


### PR DESCRIPTION
Implements code for properly reading frame headers and actually reading payloads based on the length provided by the frame header.

Fixes #129.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new Rust program for managing Discord presence with extensive activity configurations.
	- Added new error variants for improved error handling in message processing.
	- Added support for handling frame headers from Discord, potentially improving performance.

- **Bug Fixes**
	- Enhanced error handling for connection failures and message processing.
	- Fixed a compilation error for Rust version 1.69.x and addressed compatibility issues.

- **Documentation**
	- Improved clarity in the structure of enums and added new comments for understanding message framing.
	- Updated CHANGELOG to reflect recent changes and enhancements.

- **Refactor**
	- Simplified connection locking mechanisms and timeout management across various connection implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->