### PR TITLE
fix(windows): create wrapper around read() to avoid blocking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,6 @@ serde_json = "1.0"
 serde_repr = { version = "0.1", optional = true }
 thiserror = "2.0"
 
-[target.'cfg(windows)'.dependencies]
-named_pipe = "0.4"
-
 [dependencies.serde]
 features = ["derive"]
 version = "1.0"

--- a/src/connection/base.rs
+++ b/src/connection/base.rs
@@ -104,7 +104,7 @@ pub trait Connection: Sized {
         buf.resize(std::mem::size_of::<FrameHeader>(), 0);
 
         trace!("Reading header");
-        let n = self.socket().read(&mut buf)?;
+        let n = self.try_read(&mut buf)?;
         trace!("Received {} bytes for header", n);
 
         if n == 0 {
@@ -122,7 +122,7 @@ pub trait Connection: Sized {
         message_buf.resize(header.message_length(), 0);
 
         trace!("Reading payload");
-        let n = self.socket().read(&mut message_buf)?;
+        let n = self.try_read(&mut message_buf)?;
         trace!("Received {} bytes for payload", n);
 
         if n == 0 {
@@ -137,5 +137,9 @@ pub trait Connection: Sized {
             opcode: header.opcode(),
             payload,
         })
+    }
+
+    fn try_read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        Ok(self.socket().read(buf)?)
     }
 }

--- a/src/connection/windows.rs
+++ b/src/connection/windows.rs
@@ -1,21 +1,25 @@
-use std::path::PathBuf;
-
-use named_pipe::PipeClient;
+use std::{
+    fs::{File, OpenOptions},
+    io::{ErrorKind, Read},
+    os::windows::fs::OpenOptionsExt,
+    path::PathBuf,
+};
 
 use super::base::Connection;
-use crate::Result;
+use crate::{DiscordError, Result};
 
 pub struct Socket {
-    socket: PipeClient,
+    socket: File,
 }
 
 impl Connection for Socket {
-    type Socket = PipeClient;
+    type Socket = File;
 
     fn connect() -> Result<Self> {
-        let mut socket = PipeClient::connect(Self::socket_path(0))?;
-        socket.set_read_timeout(Some(Self::READ_WRITE_TIMEOUT));
-        socket.set_write_timeout(Some(Self::READ_WRITE_TIMEOUT));
+        let path = Self::socket_path(0);
+
+        let socket = OpenOptions::new().access_mode(0x3).open(&path)?;
+
         Ok(Self { socket })
     }
 
@@ -29,7 +33,7 @@ impl Connection for Socket {
 
     fn try_read(&mut self, buf: &mut [u8]) -> Result<usize> {
         if self.socket().metadata()?.len() == 0 {
-            return Err(DiscordError::IoError(Error::new(
+            return Err(DiscordError::IoError(std::io::Error::new(
                 ErrorKind::WouldBlock,
                 "No data available",
             )));

--- a/src/connection/windows.rs
+++ b/src/connection/windows.rs
@@ -26,4 +26,15 @@ impl Connection for Socket {
     fn socket(&mut self) -> &mut Self::Socket {
         &mut self.socket
     }
+
+    fn try_read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        if self.socket().metadata()?.len() == 0 {
+            return Err(DiscordError::IoError(Error::new(
+                ErrorKind::WouldBlock,
+                "No data available",
+            )));
+        }
+
+        Ok(self.socket().read(buf)?)
+    }
 }


### PR DESCRIPTION
Seems to fix #132 for me here on windows.
Feel free to close if you don't agree with the implementation.
TLDR: the (*deprecated*) `named_pipe` type doesn't support `metadata()`, with which you can check the length, i.e. if there is anything to read (i think). So that's why I had to replace it with a simple `File`.
Note that `File` doesn't support read/write timeout options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Centralized the socket read operations for improved consistency.
  - Enhanced error handling to better detect and report when no data is available.
  - Streamlined communications for increased connection stability and easier future improvements.
  - Updated socket type to enhance functionality and simplify connection methods.
- **Chores**
  - Removed the `named_pipe` dependency for Windows platforms in the project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->