### PR TITLE
Snap support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/jewlexx/discord-presence/tree/main)
 
+### Added
+
+- Support for snap installation of Discord
+
 ## [1.5.1](https://github.com/jewlexx/discord-presence/releases/tag/v1.5.1)
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "discord-presence"
 readme = "README.md"
 repository = "https://github.com/jewlexx/discord-presence.git"
 rust-version = "1.70.0"
-version = "1.5.1"
+version = "1.6.0"
 
 [features]
 activity_type = ["dep:serde_repr"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-discord-presence = "1.5"
+discord-presence = "1.6"
 ```
 
 or run:

--- a/src/connection/base.rs
+++ b/src/connection/base.rs
@@ -4,11 +4,12 @@ use crate::{
     utils,
 };
 use bytes::BytesMut;
+use quork::prelude::ListVariants;
 use serde_json::json;
 use std::{
     io::{Read, Write},
     marker::Sized,
-    path::PathBuf,
+    path::{Path, PathBuf},
     thread,
     time::{self, Duration},
 };
@@ -24,6 +25,47 @@ macro_rules! try_until_done {
 
             thread::sleep(time::Duration::from_millis(500));
         }
+    }
+}
+
+#[derive(Debug, Copy, Clone, ListVariants)]
+enum SocketLocation {
+    Root,
+    Flatpak,
+    Snap,
+    SnapCanary,
+}
+
+impl SocketLocation {
+    pub fn append_path(self, ipc_path: impl AsRef<Path>) -> PathBuf {
+        match self {
+            SocketLocation::Root => ipc_path.as_ref().to_owned(),
+            SocketLocation::Flatpak => ipc_path.as_ref().join("app").join("com.discordapp.Discord"),
+            SocketLocation::Snap => ipc_path.as_ref().join("snap.discord"),
+            SocketLocation::SnapCanary => ipc_path.as_ref().join("snap.discord-canary"),
+        }
+    }
+
+    pub fn test_paths(
+        ipc_path: impl AsRef<Path>,
+        socket_path: impl AsRef<Path>,
+    ) -> Option<PathBuf> {
+        if cfg!(windows) {
+            let path = Self::Root.append_path(ipc_path).join(socket_path);
+            return path.exists().then_some(path);
+        } else {
+            for location in Self::VARIANTS {
+                let path = location
+                    .append_path(ipc_path.as_ref())
+                    .join(socket_path.as_ref());
+
+                if path.exists() {
+                    return Some(path);
+                }
+            }
+        }
+
+        None
     }
 }
 
@@ -46,17 +88,9 @@ pub trait Connection: Sized {
     /// The full socket path.
     fn socket_path(n: u8) -> PathBuf {
         let socket_path = format!("discord-ipc-{n}");
-        let base_path = Self::ipc_path().join(socket_path.clone());
+        let ipc_path = Self::ipc_path();
 
-        if base_path.exists() {
-            base_path
-        } else {
-            // This fixes issues with Unix implementations
-            Self::ipc_path()
-                .join("app")
-                .join("com.discordapp.Discord")
-                .join(socket_path)
-        }
+        SocketLocation::test_paths(&ipc_path, &socket_path).unwrap_or(ipc_path.join(socket_path))
     }
 
     /// Perform a handshake on this socket connection.

--- a/src/connection/unix.rs
+++ b/src/connection/unix.rs
@@ -1,6 +1,6 @@
 use super::base::Connection;
 use crate::Result;
-use std::{env, net::Shutdown, os::unix::net::UnixStream, path::PathBuf, time};
+use std::{env, net::Shutdown, os::unix::net::UnixStream, path::PathBuf};
 
 pub struct Socket {
     socket: UnixStream,
@@ -13,8 +13,8 @@ impl Connection for Socket {
         let connection_name = Self::socket_path(0);
         let socket = UnixStream::connect(connection_name)?;
         socket.set_nonblocking(true)?;
-        socket.set_read_timeout(Some(Self::READ_WRITE_TIMEOUT));
-        socket.set_write_timeout(Some(Self::READ_WRITE_TIMEOUT));
+        socket.set_read_timeout(Some(Self::READ_WRITE_TIMEOUT))?;
+        socket.set_write_timeout(Some(Self::READ_WRITE_TIMEOUT))?;
         Ok(Self { socket })
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for detecting and connecting to Discord installed via Snap, alongside existing installation methods.

- **Bug Fixes**
  - Improved error handling when setting socket timeouts during connection.

- **Documentation**
  - Updated the changelog and README to document the new Snap installation support.

- **Chores**
  - Increased the package version to 1.6.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->