### PR TITLE
set unix socket to be blocking

### DIFF
--- a/src/connection/base.rs
+++ b/src/connection/base.rs
@@ -138,7 +138,7 @@ pub trait Connection: Sized {
 
         trace!("Reading header");
         let n = self.try_read(&mut buf)?;
-        trace!("Received {} bytes for header", n);
+        trace!("Received {n} bytes for header");
 
         if n == 0 {
             return Err(DiscordError::ConnectionClosed);

--- a/src/connection/unix.rs
+++ b/src/connection/unix.rs
@@ -12,7 +12,6 @@ impl Connection for Socket {
     fn connect() -> Result<Self> {
         let connection_name = Self::socket_path(0);
         let socket = UnixStream::connect(connection_name)?;
-        socket.set_nonblocking(true)?;
         socket.set_read_timeout(Some(Self::READ_WRITE_TIMEOUT))?;
         socket.set_write_timeout(Some(Self::READ_WRITE_TIMEOUT))?;
         Ok(Self { socket })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unix socket connections now use blocking mode by default, which may improve compatibility and reliability in certain environments.

- **Chores**
  - Updated internal debug log formatting for improved clarity in trace output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->