### PR TITLE
Renamed _type to activity_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `connect` function now by default checks all possible paths
 
+### Breaking
+
+- Renamed `_type` function to `activity_type`
+- Removed `activity_type` feature
+
 ## [1.6.0](https://github.com/jewlexx/discord-presence/releases/tag/v1.6.0)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ rust-version = "1.70.0"
 version = "1.6.0"
 
 [features]
-activity_type = ["dep:serde_repr"]
 unstable_name = []
 
 [package.metadata.docs.rs]
@@ -33,7 +32,6 @@ quork = { version = "0.9", default-features = false, features = [
     "traits",
 ] }
 serde_json = "1.0"
-serde_repr = { version = "0.1", optional = true }
 thiserror = "2.0"
 
 [dependencies.serde]
@@ -53,5 +51,5 @@ version-sync = "0.9"
 [[example]]
 name = "blocking_vencord"
 path = "examples/blocking_vencord.rs"
-required-features = ["unstable_name", "activity_type"]
+required-features = ["unstable_name"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "discord-presence"
 readme = "README.md"
 repository = "https://github.com/jewlexx/discord-presence.git"
 rust-version = "1.70.0"
-version = "1.6.0"
+version = "2.0.0"
 
 [features]
 unstable_name = []

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-discord-presence = "1.6"
+discord-presence = "2.0"
 ```
 
 or run:

--- a/examples/blocking_vencord.rs
+++ b/examples/blocking_vencord.rs
@@ -46,7 +46,7 @@ fn main() -> anyhow::Result<()> {
     // Set the activity
     drpc.set_activity(|act| {
         act.state("rusting frfr")
-            ._type(ActivityType::Listening)
+            .activity_type(ActivityType::Listening)
             .name("banger tunes")
             .append_buttons(|button| button.label("Click Me!").url("https://google.com/"))
     })?;

--- a/src/models/rich_presence.rs
+++ b/src/models/rich_presence.rs
@@ -97,7 +97,7 @@ builder! {Activity
     state: String,
     details: String,
     instance: bool,
-    _type: ActivityType alias = "type" => if feature = "activity_type",
+    activity_type: ActivityType alias = "type" => if feature = "activity_type",
     timestamps: ActivityTimestamps func,
     assets: ActivityAssets func,
     party: ActivityParty func,
@@ -274,7 +274,7 @@ mod feature_tests {
     fn can_serialize_activity_type() {
         use super::*;
 
-        let activity = Activity::new()._type(ActivityType::Watching);
+        let activity = Activity::new().activity_type(ActivityType::Watching);
         let json = serde_json::to_string(&activity).expect("Failed to serialize into String");
 
         assert_eq![json, r#"{"type":3}"#];

--- a/src/models/rich_presence.rs
+++ b/src/models/rich_presence.rs
@@ -2,10 +2,10 @@ use std::default::Default;
 
 use serde::Deserializer;
 
-#[cfg(feature = "activity_type")]
-use serde_repr::{Deserialize_repr, Serialize_repr};
-
 use super::events::PartialUser;
+pub use activity_type::ActivityType;
+
+mod activity_type;
 
 /// Args to set Discord activity
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -58,28 +58,6 @@ impl SendActivityJoinInviteArgs {
     }
 }
 
-/// [`ActivityType`] enum
-///
-/// Lists all activity types currently supported by Discord.
-///
-/// This may change in future if Discord adds support for more types,
-/// or removes support for some.
-#[cfg(feature = "activity_type")]
-#[cfg_attr(docsrs, doc(cfg(feature = "activity_type")))]
-#[repr(u8)]
-#[non_exhaustive]
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize_repr, Serialize_repr, Hash)]
-pub enum ActivityType {
-    /// Playing a game
-    Playing = 0,
-    /// Listening to...
-    Listening = 2,
-    /// Watching...
-    Watching = 3,
-    /// Competing in...
-    Competing = 5,
-}
-
 builder! {ActivityJoinEvent
     secret: String,
 }
@@ -97,7 +75,7 @@ builder! {Activity
     state: String,
     details: String,
     instance: bool,
-    activity_type: ActivityType alias = "type" => if feature = "activity_type",
+    activity_type: ActivityType alias = "type",
     timestamps: ActivityTimestamps func,
     assets: ActivityAssets func,
     party: ActivityParty func,
@@ -264,12 +242,7 @@ mod tests {
         let json = serde_json::to_string(&activity).expect("Failed to serialize into String");
         assert_eq![json, "{}"];
     }
-}
 
-#[cfg(test)]
-mod feature_tests {
-
-    #[cfg(feature = "activity_type")]
     #[test]
     fn can_serialize_activity_type() {
         use super::*;
@@ -279,7 +252,10 @@ mod feature_tests {
 
         assert_eq![json, r#"{"type":3}"#];
     }
+}
 
+#[cfg(test)]
+mod feature_tests {
     #[cfg(feature = "unstable_name")]
     #[test]
     fn can_serialize_activity_name() {

--- a/src/models/rich_presence/activity_type.rs
+++ b/src/models/rich_presence/activity_type.rs
@@ -1,0 +1,59 @@
+/// [`ActivityType`] enum
+///
+/// Lists all activity types currently supported by Discord.
+///
+/// This may change in future if Discord adds support for more types,
+/// or removes support for some.
+#[repr(u8)]
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum ActivityType {
+    /// Playing a game
+    Playing = 0,
+    /// Listening to...
+    Listening = 2,
+    /// Watching...
+    Watching = 3,
+    /// Competing in...
+    Competing = 5,
+}
+
+impl<'de> serde::Deserialize<'de> for ActivityType {
+    #[allow(clippy::use_self)]
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const PLAYING: u8 = ActivityType::Playing as u8;
+        const LISTENING: u8 = ActivityType::Listening as u8;
+        const WATCHING: u8 = ActivityType::Watching as u8;
+        const COMPETING: u8 = ActivityType::Competing as u8;
+
+        match u8::deserialize(deserializer)? {
+            PLAYING => Result::Ok(ActivityType::Playing),
+            LISTENING => Result::Ok(ActivityType::Listening),
+            WATCHING => Result::Ok(ActivityType::Watching),
+            COMPETING => Result::Ok(ActivityType::Competing),
+            other => Result::Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Unsigned(u64::from(other)),
+                &(&format!("one of: {PLAYING}, {LISTENING}, {WATCHING}, {COMPETING}") as &str),
+            )),
+        }
+    }
+}
+
+impl serde::Serialize for ActivityType {
+    #[allow(clippy::use_self)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = match *self {
+            ActivityType::Playing => ActivityType::Playing as u8,
+            ActivityType::Listening => ActivityType::Listening as u8,
+            ActivityType::Watching => ActivityType::Watching as u8,
+            ActivityType::Competing => ActivityType::Competing as u8,
+        };
+        serde::Serialize::serialize(&value, serializer)
+    }
+}


### PR DESCRIPTION
I've deemed activity_type to be stable and widely supported enough to be given a proper function name and have its feature flag removed to be enabled by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed the field for specifying activity type in Discord presence from `_type` to `activity_type`.
  * Removed the `activity_type` feature and related optional dependency.
* **New Features**
  * Introduced a new `ActivityType` enum for Discord activities, supporting Playing, Listening, Watching, and Competing.
* **Documentation**
  * Updated changelog to reflect breaking changes and new version.
* **Chores**
  * Bumped package version to 2.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->