### PR TITLE
fix retrying blocking operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/jewlexx/discord-presence/tree/main)
 
+### Fixed
+
+- RPC on Windows not retrying when I/O would block
+
 ## [2.0.0](https://github.com/jewlexx/discord-presence/releases/tag/v2.0.0)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,4 +52,3 @@ version-sync = "0.9"
 name = "blocking_vencord"
 path = "examples/blocking_vencord.rs"
 required-features = ["unstable_name"]
-

--- a/src/connection/base.rs
+++ b/src/connection/base.rs
@@ -3,7 +3,7 @@ use std::{
     marker::Sized,
     path::PathBuf,
     thread,
-    time::{self, Duration},
+    time::Duration,
 };
 
 use bytes::BytesMut;
@@ -16,15 +16,18 @@ use crate::{
 };
 
 /// Wait for a non-blocking connection until it's complete.
-fn try_until_done<T>(result: Result<T>) -> Result<T> {
+fn try_until_done<T, F>(mut operation: F) -> Result<T>
+where
+    F: FnMut() -> Result<T>,
+{
     loop {
-        match result {
+        match operation() {
             Ok(v) => return Ok(v),
             Err(why) if !why.io_would_block() => return Err(why),
             _ => {}
         }
 
-        thread::sleep(time::Duration::from_micros(500));
+        thread::sleep(Duration::from_micros(500));
     }
 }
 
@@ -66,8 +69,10 @@ pub trait Connection: Sized {
         }];
 
         let msg = Message::new(OpCode::Handshake, hs)?;
-        try_until_done(self.send(&msg))?;
-        let msg = try_until_done(self.recv())?;
+
+        try_until_done(|| self.send(&msg))?;
+
+        let msg = try_until_done(|| self.recv())?;
 
         Ok(msg)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where RPC on Windows did not retry when an I/O operation would block.

* **Refactor**
  * Improved internal retry logic for connection operations to enhance reliability.

* **Chores**
  * Updated changelog to document the fixed issue.
  * Minor formatting cleanup in configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->