### PR TITLE
Added option to modify status display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/jewlexx/discord-presence/tree/main)
 
+### Added
+
+- Option to change display type in line with [Discord's changelog](https://discord.com/developers/docs/change-log#clickable-links-and-customizable-statuses-in-rich-presence)
+
 ### Fixed
 
 - RPC on Windows not retrying when I/O would block

--- a/examples/blocking_vencord.rs
+++ b/examples/blocking_vencord.rs
@@ -1,4 +1,7 @@
-use discord_presence::{models::ActivityType, Client, Event};
+use discord_presence::{
+    models::{ActivityType, DisplayType},
+    Client, Event,
+};
 
 mod helpers;
 
@@ -46,8 +49,9 @@ fn main() -> anyhow::Result<()> {
     // Set the activity
     drpc.set_activity(|act| {
         act.state("rusting frfr")
-            .activity_type(ActivityType::Listening)
             .name("banger tunes")
+            .activity_type(ActivityType::Listening)
+            .status_display(DisplayType::State)
             .append_buttons(|button| button.label("Click Me!").url("https://google.com/"))
     })?;
 

--- a/src/models/rich_presence.rs
+++ b/src/models/rich_presence.rs
@@ -4,8 +4,10 @@ use serde::Deserializer;
 
 use super::events::PartialUser;
 pub use activity_type::ActivityType;
+pub use display_type::DisplayType;
 
 mod activity_type;
+mod display_type;
 
 /// Args to set Discord activity
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -75,6 +77,7 @@ builder! {Activity
     state: String,
     details: String,
     instance: bool,
+    status_display: DisplayType alias = "status_display_type",
     activity_type: ActivityType alias = "type",
     timestamps: ActivityTimestamps func,
     assets: ActivityAssets func,

--- a/src/models/rich_presence/display_type.rs
+++ b/src/models/rich_presence/display_type.rs
@@ -1,0 +1,54 @@
+/// [`DisplayType`] enum
+///
+/// Lists all activity types currently supported by Discord.
+///
+/// This may change in future if Discord adds support for more types,
+/// or removes support for some.
+#[repr(u8)]
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum DisplayType {
+    /// Playing a game
+    Name = 0,
+    /// Listening to...
+    State = 1,
+    /// Watching...
+    Details = 2,
+}
+
+impl<'de> serde::Deserialize<'de> for DisplayType {
+    #[allow(clippy::use_self)]
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const NAME: u8 = DisplayType::Name as u8;
+        const STATE: u8 = DisplayType::State as u8;
+        const DETAILS: u8 = DisplayType::Details as u8;
+
+        match u8::deserialize(deserializer)? {
+            NAME => Result::Ok(DisplayType::Name),
+            STATE => Result::Ok(DisplayType::State),
+            DETAILS => Result::Ok(DisplayType::Details),
+            other => Result::Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Unsigned(u64::from(other)),
+                &(&format!("one of: {NAME}, {STATE}, {DETAILS}") as &str),
+            )),
+        }
+    }
+}
+
+impl serde::Serialize for DisplayType {
+    #[allow(clippy::use_self)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = match *self {
+            DisplayType::Name => DisplayType::Name as u8,
+            DisplayType::State => DisplayType::State as u8,
+            DisplayType::Details => DisplayType::Details as u8,
+        };
+        serde::Serialize::serialize(&value, serializer)
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the display type of rich presence activities, allowing users to choose between different status display options.

* **Documentation**
  * Updated changelog to document the new display type option for rich presence activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->