### PR TITLE
Restore non-blocking setting for unix clients

### DIFF
--- a/src/connection/os/unix.rs
+++ b/src/connection/os/unix.rs
@@ -16,6 +16,7 @@ impl Connection for Socket {
     fn connect_with_id(id: SocketId) -> Result<Self> {
         let connection_name = Self::socket_path(id);
         let socket = UnixStream::connect(connection_name)?;
+        socket.set_nonblocking(true)?;
         socket.set_read_timeout(Some(Self::READ_WRITE_TIMEOUT))?;
         socket.set_write_timeout(Some(Self::READ_WRITE_TIMEOUT))?;
         Ok(Self { socket })


### PR DESCRIPTION
It seems without the call to `socket.set_nonblocking(true)` the socket waits the full timeout for every single RPC call. This PR reverses that change allowing the socket to immediately update RPC when needed.

Closes #147 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unix socket connection handling with optimized I/O configuration for enhanced reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->