### PR TITLE
Detect broken pipes on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,9 @@ quork = { version = "0.9", default-features = false, features = [
 serde_json = "1.0"
 thiserror = "2.0"
 
-[target.'cfg(windows)'.dependencies.winapi]
-features = ["namedpipeapi", "errhandlingapi", "winerror"]
-version = "0.3.9"
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.61.2"
+features = ["Win32_Foundation", "Win32_System_Pipes"]
 
 [dependencies.serde]
 features = ["derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ quork = { version = "0.9", default-features = false, features = [
 serde_json = "1.0"
 thiserror = "2.0"
 
+[target.'cfg(windows)'.dependencies.winapi]
+features = ["namedpipeapi", "errhandlingapi", "winerror"]
+version = "0.3.9"
+
 [dependencies.serde]
 features = ["derive"]
 version = "1.0"

--- a/src/connection/os/windows.rs
+++ b/src/connection/os/windows.rs
@@ -1,13 +1,15 @@
 use std::{
     fs::{File, OpenOptions},
-    io::{ErrorKind, Read},
-    os::windows::fs::OpenOptionsExt,
+    io::{self, Read},
+    os::windows::{fs::OpenOptionsExt, io::AsRawHandle},
     path::PathBuf,
+    ptr,
 };
 
+use winapi::{ctypes::c_void, shared::{minwindef::DWORD, winerror::ERROR_BROKEN_PIPE}, um::{errhandlingapi::GetLastError, namedpipeapi::PeekNamedPipe}};
+
 use crate::{
-    connection::{base::Connection, location::SocketId},
-    DiscordError, Result,
+    DiscordError, Result, connection::{base::Connection, location::SocketId}
 };
 
 /// Socket connection for Windows systems.
@@ -35,11 +37,33 @@ impl Connection for Socket {
     }
 
     fn try_read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        if self.socket().metadata()?.len() == 0 {
-            return Err(DiscordError::IoError(std::io::Error::new(
-                ErrorKind::WouldBlock,
-                "No data available",
-            )));
+        // peek the pipe to see if there is data available
+        let mut bytes_available: DWORD = 0;
+        let ok = unsafe {
+            PeekNamedPipe(
+                self.socket().as_raw_handle() as *mut c_void,
+                ptr::null_mut(),
+                0,
+                ptr::null_mut(),
+                &mut bytes_available,
+                ptr::null_mut(),
+            )
+        } != 0;
+
+        // an error occurred while peeking the pipe
+        if !ok {
+            let err = unsafe { GetLastError() };
+
+            // if the pipe is broken, treat it as EOF
+            if err == ERROR_BROKEN_PIPE {
+                return Ok(0);
+            } else {
+                return Err(DiscordError::IoError(io::Error::from_raw_os_error(err as i32)));
+            }
+        }
+
+        if bytes_available == 0{
+            return Err(DiscordError::IoError(io::Error::new(io::ErrorKind::WouldBlock, "No data available")));
         }
 
         Ok(self.socket().read(buf)?)

--- a/src/connection/os/windows.rs
+++ b/src/connection/os/windows.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::c_void,
     fs::{File, OpenOptions},
     io::{self, Read},
     os::windows::{fs::OpenOptionsExt, io::AsRawHandle},
@@ -6,10 +7,14 @@ use std::{
     ptr,
 };
 
-use winapi::{ctypes::c_void, shared::{minwindef::DWORD, winerror::ERROR_BROKEN_PIPE}, um::{errhandlingapi::GetLastError, namedpipeapi::PeekNamedPipe}};
+use windows_sys::Win32::{
+    Foundation::{GetLastError, ERROR_BROKEN_PIPE},
+    System::Pipes::PeekNamedPipe,
+};
 
 use crate::{
-    DiscordError, Result, connection::{base::Connection, location::SocketId}
+    connection::{base::Connection, location::SocketId},
+    DiscordError, Result,
 };
 
 /// Socket connection for Windows systems.
@@ -38,7 +43,7 @@ impl Connection for Socket {
 
     fn try_read(&mut self, buf: &mut [u8]) -> Result<usize> {
         // peek the pipe to see if there is data available
-        let mut bytes_available: DWORD = 0;
+        let mut bytes_available: u32 = 0;
         let ok = unsafe {
             PeekNamedPipe(
                 self.socket().as_raw_handle() as *mut c_void,
@@ -58,12 +63,17 @@ impl Connection for Socket {
             if err == ERROR_BROKEN_PIPE {
                 return Ok(0);
             } else {
-                return Err(DiscordError::IoError(io::Error::from_raw_os_error(err as i32)));
+                return Err(DiscordError::IoError(io::Error::from_raw_os_error(
+                    err as i32,
+                )));
             }
         }
 
-        if bytes_available == 0{
-            return Err(DiscordError::IoError(io::Error::new(io::ErrorKind::WouldBlock, "No data available")));
+        if bytes_available == 0 {
+            return Err(DiscordError::IoError(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "No data available",
+            )));
         }
 
         Ok(self.socket().read(buf)?)


### PR DESCRIPTION
`try_read` didn't detect broken pipes due to the length check. I've changed it so that it tries to peek data on the pipe, and returns errors accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Windows Improvements**
  * Improved named-pipe connection handling with more accurate data-available checks.
  * Better Windows-specific error handling, treating broken pipes as EOF and surfacing appropriate I/O errors.

* **Chores**
  * Added/updated a Windows-only dependency to support the new platform-specific behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->