### PR TITLE
replace paste with pastey

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4"
 num-derive = "0.4"
 num-traits = "0.2"
 parking_lot = "0.12"
-paste = "1.0"
+pastey = "0.2.1"
 quork = { version = "0.9", default-features = false, features = [
     "macros",
     "traits",

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -53,7 +53,7 @@ macro_rules! builder_array_doc {
 
 macro_rules! builder_array {
     [ $name:ident, $type:tt array ] => {
-        paste::paste! {
+        pastey::paste! {
             #[doc = builder_array_doc!($type)]
             #[must_use]
             pub fn [<append_ $name>]<F>(mut self, func: F) -> Self


### PR DESCRIPTION
The [paste](https://github.com/dtolnay/paste) crate has been unmaintained since October 2024. Perhaps the crate should depend on a fork which is maintained for future-proofing, such as [pastey](https://github.com/AS1100K/pastey)?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies for package maintenance and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->