### PR TITLE
Internal rate limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/jewlexx/discord-presence/tree/trunk)
 
+- Added rate limiter under `rate_limiter` feature flag.
+  - New method `queue_activity` to queue new activities.
+  - `set_activity` does not respect rate limits and will always send immediately.
+
 ## [3.1.0](https://github.com/jewlexx/discord-presence/releases/tag/v3.1.0)
 
 ### Changed

--- a/examples/rate_limit.rs
+++ b/examples/rate_limit.rs
@@ -1,0 +1,36 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use discord_presence::{models::ActivityTimestamps, Client, Event};
+
+mod helpers;
+
+fn main() -> anyhow::Result<()> {
+    helpers::logging::init_logging();
+
+    // wait until the rpc client is ready
+    let mut client = Client::new(1286481105410588672);
+    client.start();
+    client.block_until_event(Event::Ready)?;
+
+    // set an activity every second for 30 seconds
+    // we expect that it only updates ~every 15 seconds
+    let timestamps =
+        ActivityTimestamps::new().start(SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs());
+    for i in 0..=30 {
+        let state = format!("{} seconds", i);
+        client.queue_activity(|act| act.state(&state).timestamps(|_| timestamps.clone()));
+        std::thread::sleep(Duration::from_secs(1));
+    }
+
+    // we can also override the queued activity by using set_activity
+    // which will always try to send immediately
+    client.queue_activity(|act| {
+        act.state("this will never appear...")
+            .timestamps(|_| timestamps.clone())
+    });
+    std::thread::sleep(Duration::from_secs(3));
+    client.set_activity(|act| act.state("done!").timestamps(|_| timestamps.clone()))?;
+    client.block_on()?;
+
+    Ok(())
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -245,7 +245,6 @@ impl Client {
         // if the activity update was successful, mark it as sent in the rate limiter
         if result.is_ok() {
             self.connection_manager.rate_limiter.mark_sent();
-            self.connection_manager.rate_limiter.take_queued();
         }
 
         result
@@ -262,7 +261,7 @@ impl Client {
     {
         self.connection_manager
             .rate_limiter
-            .queue_activity(SetActivityArgs::new(f));
+            .queue(SetActivityArgs::new(f));
     }
 
     // NOTE: Not sure what the actual response values of

--- a/src/client.rs
+++ b/src/client.rs
@@ -109,6 +109,7 @@ impl Client {
         attempts: Option<usize>,
     ) -> Self {
         let event_handler_registry = Arc::new(HandlerRegistry::new());
+
         let connection_manager = ConnectionManager::new(
             client_id,
             event_handler_registry.clone(),
@@ -217,7 +218,7 @@ impl Client {
         }
     }
 
-    /// Set the users current activity
+    /// Set the users current activity immediately
     ///
     /// # Errors
     /// - See [`DiscordError`] for more info
@@ -225,7 +226,8 @@ impl Client {
     where
         F: FnOnce(Activity) -> Activity,
     {
-        self.execute(Command::SetActivity, SetActivityArgs::new(f), None)
+        let args = SetActivityArgs::new(f);
+        self.update_activity(args)
     }
 
     /// Clear the users current activity
@@ -233,7 +235,34 @@ impl Client {
     /// # Errors
     /// - See [`DiscordError`] for more info
     pub fn clear_activity(&mut self) -> Result<Payload<Activity>> {
-        self.execute(Command::SetActivity, SetActivityArgs::default(), None)
+        self.update_activity(SetActivityArgs::default())
+    }
+
+    /// Update the current user's activity immediately
+    fn update_activity(&mut self, args: SetActivityArgs) -> Result<Payload<Activity>> {
+        let result = self.execute(Command::SetActivity, args, None);
+
+        // if the activity update was successful, mark it as sent in the rate limiter
+        if result.is_ok() {
+            self.connection_manager.rate_limiter.mark_sent();
+            self.connection_manager.rate_limiter.take_queued();
+        }
+
+        result
+    }
+
+    /// Queue an activity update to be sent at the next rate limit interval.
+    ///
+    /// Unlike [`Client::set_activity`], this doesn't send the activity immediately.
+    /// Instead, it queues the update to be sent when the rate limiter allows.
+    /// If multiple activities are queued, only the most recent one will be sent.
+    pub fn queue_activity<F>(&mut self, f: F)
+    where
+        F: FnOnce(Activity) -> Activity,
+    {
+        self.connection_manager
+            .rate_limiter
+            .queue_activity(SetActivityArgs::new(f));
     }
 
     // NOTE: Not sure what the actual response values of

--- a/src/connection/base.rs
+++ b/src/connection/base.rs
@@ -36,6 +36,7 @@ pub trait Connection: Sized {
 
     /// Time for socket read/write operations
     /// 1 second higher than Discord's rate limit timeout of 15 seconds
+    #[cfg(unix)]
     const READ_WRITE_TIMEOUT: Duration = Duration::from_secs(16);
 
     /// The internally stored socket connection.

--- a/src/connection/manager.rs
+++ b/src/connection/manager.rs
@@ -1,9 +1,10 @@
 use super::{Connection, Socket};
-use crate::models::EventData;
+use crate::models::{rich_presence::SetActivityArgs, Command, OpCode};
 use crate::{
     error::{DiscordError, Result},
     event_handler::HandlerRegistry,
-    models::{payload::Payload, ErrorEvent, Event, Message},
+    models::{payload::Payload, ErrorEvent, Event, EventData, Message},
+    rate_limiter::{RateLimiter},
 };
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use parking_lot::Mutex;
@@ -30,6 +31,7 @@ pub struct Manager {
     event_handler_registry: Arc<HandlerRegistry>,
     error_sleep: Duration,
     connection_attempts: Arc<Mutex<Option<usize>>>,
+    pub(crate) rate_limiter: RateLimiter,
 }
 
 impl Manager {
@@ -52,17 +54,26 @@ impl Manager {
             event_handler_registry,
             error_sleep,
             connection_attempts: Arc::new(Mutex::new(connection_attempts)),
+            rate_limiter: RateLimiter::default(),
         }
     }
 
     /// Start the connection manager
-    pub fn start(&mut self, rx: Receiver<()>) -> std::thread::JoinHandle<()> {
+    pub fn start(&mut self, rx: Receiver<()>) -> thread::JoinHandle<()> {
         let mut manager_inner = self.clone();
         let error_sleep = self.error_sleep;
         let connection_attempts = self.connection_attempts.clone();
+        let rate_limiter = self.rate_limiter.clone();
+
         thread::spawn(move || {
             // TODO: Refactor so that JSON values are consistent across errors
-            send_and_receive_loop(&mut manager_inner, &rx, error_sleep, &connection_attempts);
+            send_and_receive_loop(
+                &mut manager_inner,
+                &rx,
+                error_sleep,
+                &connection_attempts,
+                &rate_limiter,
+            );
         })
     }
 
@@ -121,11 +132,13 @@ impl Manager {
     }
 }
 
+#[allow(clippy::trivially_copy_pass_by_ref)]
 fn send_and_receive_loop(
     manager: &mut Manager,
     rx: &Receiver<()>,
     err_sleep: Duration,
     connection_attempts: &Arc<Mutex<Option<usize>>>,
+    rate_limiter: &RateLimiter,
 ) {
     trace!("Starting sender loop");
 
@@ -141,6 +154,31 @@ fn send_and_receive_loop(
 
         match *connection {
             Some(ref conn) => {
+                // check if there's a queued activity that can be sent
+                if rate_limiter.can_send() && rate_limiter.try_claim_send() {
+                    if let Some(args) = rate_limiter.take_queued() {
+                        trace!("Sending queued activity");
+                        let message = Message::new(
+                            OpCode::Frame,
+                            Payload::<SetActivityArgs>::with_nonce(
+                                Command::SetActivity,
+                                Some(args),
+                                None,
+                                None,
+                            ),
+                        );
+
+                        if let Ok(msg) = message {
+                            if conn.lock().send(&msg).is_ok() {
+                                rate_limiter.mark_sent();
+                                trace!("Queued activity sent successfully");
+                            }
+                        }
+                    }
+
+                    rate_limiter.release_send();
+                }
+
                 match send_and_receive(
                     &mut conn.lock(),
                     &manager.event_handler_registry,

--- a/src/connection/manager.rs
+++ b/src/connection/manager.rs
@@ -4,7 +4,7 @@ use crate::{
     error::{DiscordError, Result},
     event_handler::HandlerRegistry,
     models::{payload::Payload, ErrorEvent, Event, EventData, Message},
-    rate_limiter::{RateLimiter},
+    rate_limiter::RateLimiter,
 };
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use parking_lot::Mutex;
@@ -155,30 +155,32 @@ fn send_and_receive_loop(
         match *connection {
             Some(ref conn) => {
                 // check if there's a queued activity that can be sent
-                if rate_limiter.can_send() && rate_limiter.try_claim_send() {
-                    if let Some(args) = rate_limiter.take_queued() {
-                        trace!("Sending queued activity");
-                        let message = Message::new(
-                            OpCode::Frame,
-                            Payload::<SetActivityArgs>::with_nonce(
-                                Command::SetActivity,
-                                Some(args),
-                                None,
-                                None,
-                            ),
-                        );
+                if let Some(args) = rate_limiter.peek_queued() {
+                    trace!("Sending queued activity");
+                    let message = Message::new(
+                        OpCode::Frame,
+                        Payload::<SetActivityArgs>::with_nonce(
+                            Command::SetActivity,
+                            Some(args),
+                            None,
+                            None,
+                        ),
+                    );
 
-                        if let Ok(msg) = message {
-                            if conn.lock().send(&msg).is_ok() {
-                                rate_limiter.mark_sent();
-                                trace!("Queued activity sent successfully");
-                            }
+                    if let Ok(msg) = message {
+                        if conn.lock().send(&msg).is_ok() {
+                            rate_limiter.mark_sent();
+                            trace!("Queued activity sent successfully");
+                        } else {
+                            rate_limiter.release_send();
+                            trace!("Failed to send queued activity, will retry later");
                         }
+                    } else {
+                        rate_limiter.drop_queued();
+                        trace!("Failed to create message for queued activity, dropping it");
                     }
-
-                    rate_limiter.release_send();
                 }
-
+                
                 match send_and_receive(
                     &mut conn.lock(),
                     &manager.event_handler_registry,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ pub mod error;
 pub mod event_handler;
 /// Models for discord activity
 pub mod models;
+/// Rate limiting functionality
+mod rate_limiter;
 
 pub(crate) fn nonce() -> String {
     uuid::Uuid::new_v4().to_string()

--- a/src/models/rich_presence.rs
+++ b/src/models/rich_presence.rs
@@ -10,7 +10,7 @@ mod activity_type;
 mod display_type;
 
 /// Args to set Discord activity
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct SetActivityArgs {
     pid: u32,
 

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -1,8 +1,5 @@
 use std::{
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -10,50 +7,56 @@ use parking_lot::Mutex;
 
 use crate::models::rich_presence::SetActivityArgs;
 
-#[derive(Clone, Default)]
-pub struct RateLimiter {
-    last_activity_update: Arc<Mutex<Option<Instant>>>,
-    queued_activity: Arc<Mutex<Option<SetActivityArgs>>>,
-    claiming_send: Arc<AtomicBool>,
+#[derive(Default)]
+struct RateLimiterState {
+    last_update: Option<Instant>,
+    queued: Option<SetActivityArgs>,
+    is_sending: bool,
 }
 
+#[derive(Clone, Default)]
+pub struct RateLimiter(Arc<Mutex<RateLimiterState>>);
+
 impl RateLimiter {
+    const RATE_LIMIT: Duration = Duration::from_secs(15);
+
     /// Queue an activity update to be sent later.
-    pub(crate) fn queue_activity(&self, args: SetActivityArgs) {
-        let mut queued = self.queued_activity.lock();
-        *queued = Some(args);
+    pub(crate) fn queue(&self, args: SetActivityArgs) {
+        let mut state = self.0.lock();
+        state.queued = Some(args);
     }
 
-    /// Can we send an activity update right now?
-    pub(crate) fn can_send(&self) -> bool {
-        const RATE_LIMIT: Duration = Duration::from_secs(15);
-        let last_update = self.last_activity_update.lock();
-        last_update
-            .map(|t| t.elapsed() >= RATE_LIMIT)
-            .unwrap_or(true)
-    }
-
-    /// Mark that we have just sent an activity update.
+    /// Mark that an activity update has been sent now.
     pub(crate) fn mark_sent(&self) {
-        let mut last_update = self.last_activity_update.lock();
-        *last_update = Some(Instant::now());
-        let mut queued = self.queued_activity.lock();
-        *queued = None;
+        let mut state = self.0.lock();
+        state.last_update = Some(Instant::now());
+        state.queued = None;
+        state.is_sending = false;
     }
 
-    /// Take the queued activity update, if any.
-    pub(crate) fn take_queued(&self) -> Option<SetActivityArgs> {
-        let mut queued = self.queued_activity.lock();
-        queued.take()
-    }
-
-    /// Try to claim the send lock. Returns true if successful.
-    pub(crate) fn try_claim_send(&self) -> bool {
-        !self.claiming_send.swap(true, Ordering::SeqCst)
-    }
-
-    /// Release the send lock.
+    /// Release the send lock without updating timestamp.
     pub(crate) fn release_send(&self) {
-        self.claiming_send.store(false, Ordering::SeqCst);
+        self.0.lock().is_sending = false;
+    }
+
+    /// Peek at the queued activity update if it can be sent now.
+    pub(crate) fn peek_queued(&self) -> Option<SetActivityArgs> {
+        let mut state = self.0.lock();
+        let can_send = state
+            .last_update
+            .is_none_or(|t| t.elapsed() >= Self::RATE_LIMIT);
+
+        if can_send && !state.is_sending {
+            state.is_sending = true;
+            state.queued.clone()
+        } else {
+            None
+        }
+    }
+
+    /// Drop the queued activity update without sending it.
+    pub(crate) fn drop_queued(&self) {
+        let mut state = self.0.lock();
+        state.queued = None;
     }
 }

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -1,0 +1,59 @@
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+use parking_lot::Mutex;
+
+use crate::models::rich_presence::SetActivityArgs;
+
+#[derive(Clone, Default)]
+pub struct RateLimiter {
+    last_activity_update: Arc<Mutex<Option<Instant>>>,
+    queued_activity: Arc<Mutex<Option<SetActivityArgs>>>,
+    claiming_send: Arc<AtomicBool>,
+}
+
+impl RateLimiter {
+    /// Queue an activity update to be sent later.
+    pub(crate) fn queue_activity(&self, args: SetActivityArgs) {
+        let mut queued = self.queued_activity.lock();
+        *queued = Some(args);
+    }
+
+    /// Can we send an activity update right now?
+    pub(crate) fn can_send(&self) -> bool {
+        const RATE_LIMIT: Duration = Duration::from_secs(15);
+        let last_update = self.last_activity_update.lock();
+        last_update
+            .map(|t| t.elapsed() >= RATE_LIMIT)
+            .unwrap_or(true)
+    }
+
+    /// Mark that we have just sent an activity update.
+    pub(crate) fn mark_sent(&self) {
+        let mut last_update = self.last_activity_update.lock();
+        *last_update = Some(Instant::now());
+        let mut queued = self.queued_activity.lock();
+        *queued = None;
+    }
+
+    /// Take the queued activity update, if any.
+    pub(crate) fn take_queued(&self) -> Option<SetActivityArgs> {
+        let mut queued = self.queued_activity.lock();
+        queued.take()
+    }
+
+    /// Try to claim the send lock. Returns true if successful.
+    pub(crate) fn try_claim_send(&self) -> bool {
+        !self.claiming_send.swap(true, Ordering::SeqCst)
+    }
+
+    /// Release the send lock.
+    pub(crate) fn release_send(&self) {
+        self.claiming_send.store(false, Ordering::SeqCst);
+    }
+}

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -47,8 +47,12 @@ impl RateLimiter {
             .is_none_or(|t| t.elapsed() >= Self::RATE_LIMIT);
 
         if can_send && !state.is_sending {
-            state.is_sending = true;
-            state.queued.clone()
+            if let Some(args) = state.queued.clone() {
+                state.is_sending = true;
+                Some(args)
+            } else {
+                None
+            }
         } else {
             None
         }
@@ -58,5 +62,6 @@ impl RateLimiter {
     pub(crate) fn drop_queued(&self) {
         let mut state = self.0.lock();
         state.queued = None;
+        state.is_sending = false;
     }
 }


### PR DESCRIPTION
This PR adds an internal rate limiter that queues the latest activity to apply at the end of the interval. There is also an example that demonstrates it working by trying to update the state every second - you will be able to inspect that it only updates every 15 seconds. I also gated `Connection::READ_WRITE_TIMEOUT` to only compile on unix systems as it isn't used on Windows. Closes #23.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API to queue a pending activity update and a built-in rate limiter (15s throttle); immediate updates still send instantly
  * Connection manager now honors queued activity sends

* **Examples**
  * New example demonstrating periodic presence/activity updates with the rate limiter

* **Documentation**
  * CHANGELOG updated with rate limiting and queuing details

* **Chores**
  * Platform-specific trait timeout now guarded on Unix targets

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->